### PR TITLE
[FLOC-3662] Add options for storing and suppressing Twisted logs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,10 @@ Changes
 * ``testtools.deferredruntest.run_with_log_observers`` is deprecated.
   (Jonathan Lange)
 
+* ``AsynchronousDeferredRunTest`` now has ``suppress_twisted_logging`` and
+  ``store_twisted_logs`` parameters that can be used to override the default
+  logging behaviour.  (Jonathan Lange, #942785)
+
 
 1.8.1
 ~~~~~

--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,10 @@ Changes
   ``store_twisted_logs`` parameters that can be used to override the default
   logging behaviour.  (Jonathan Lange, #942785)
 
+* New fixture ``CaptureTwistedLogs`` that can be used with
+  ``AsynchronousDeferredRunTest`` to attach a detail containing everything
+  logged to Twisted during the test run.  (Jonathan Lange, #1515362)
+
 
 1.8.1
 ~~~~~

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -128,7 +128,7 @@ class _ErrorObserver(Fixture):
         return self._error_observer.flushErrors(*error_types)
 
 
-class _CaptureTwistedLogs(Fixture):
+class CaptureTwistedLogs(Fixture):
     """Capture all the Twisted logs and add them as a detail."""
 
     LOG_DETAIL_NAME = 'twisted-log'
@@ -335,7 +335,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         if self._suppress_twisted_logging:
             self.case.useFixture(_NoTwistedLogObservers())
         if self._store_twisted_logs:
-            self.case.useFixture(_CaptureTwistedLogs())
+            self.case.useFixture(CaptureTwistedLogs())
 
         with _ErrorObserver(_log_observer) as error_fixture:
             successful, unhandled = self._blocking_run_deferred(

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -224,11 +224,15 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
     def make_result(self):
         return ExtendedTestResult()
 
-    def make_runner(self, test, timeout=None):
+    def make_runner(self, test, timeout=None, suppress_twisted_logging=True,
+                    store_twisted_logs=True):
         if timeout is None:
             timeout = self.make_timeout()
         return AsynchronousDeferredRunTest(
-            test, test.exception_handlers, timeout=timeout)
+            test, test.exception_handlers, timeout=timeout,
+            suppress_twisted_logging=suppress_twisted_logging,
+            store_twisted_logs=store_twisted_logs,
+        )
 
     def make_timeout(self):
         return 0.005
@@ -604,7 +608,7 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                     f = failure.Failure()
                 log.err(f)
         test = LogAnError('test_something')
-        runner = self.make_runner(test)
+        runner = self.make_runner(test, store_twisted_logs=False)
         result = self.make_result()
         runner.run(result)
         self.assertThat(
@@ -613,10 +617,6 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                 ('startTest', test),
                 ('addError', test, {
                     'logged-error': AsText(ContainsAll([
-                        'Traceback (most recent call last):',
-                        'ZeroDivisionError',
-                        ])),
-                    'twisted-log': AsText(ContainsAll([
                         'Traceback (most recent call last):',
                         'ZeroDivisionError',
                         ])),
@@ -635,28 +635,25 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                 log.err(f)
                 flush_logged_errors(ZeroDivisionError)
         test = LogAnError('test_something')
-        runner = self.make_runner(test)
+        runner = self.make_runner(test, store_twisted_logs=False)
         result = self.make_result()
         runner.run(result)
         self.assertThat(
             result._events,
             MatchesEvents(
                 ('startTest', test),
-                ('addSuccess', test, {
-                    'twisted-log': AsText(ContainsAll([
-                        'Traceback (most recent call last):',
-                        'ZeroDivisionError',
-                        ])),
-                    }),
+                ('addSuccess', test),
                 ('stopTest', test)))
 
     def test_log_in_details(self):
+        # If store_twisted_logs is True, we include the Twisted logs as
+        # details.
         class LogAnError(TestCase):
             def test_something(self):
                 log.msg("foo")
                 1/0
         test = LogAnError('test_something')
-        runner = self.make_runner(test)
+        runner = self.make_runner(test, store_twisted_logs=True)
         result = self.make_result()
         runner.run(result)
         self.assertThat(
@@ -670,9 +667,8 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                 ('stopTest', test)))
 
     def test_do_not_log_to_twisted(self):
-        # By default, we don't log anything to the default Twisted loggers.
-        # XXX: We want to make this behaviour optional, and (ideally)
-        # deprecated.
+        # If suppress_twisted_logging is True, we don't log anything to the
+        # default Twisted loggers.
         messages = []
         publisher, _ = _get_global_publisher_and_observers()
         publisher.addObserver(messages.append)
@@ -682,10 +678,29 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                 log.msg("foo")
 
         test = LogSomething('test_something')
-        runner = self.make_runner(test)
+        runner = self.make_runner(test, suppress_twisted_logging=True)
         result = self.make_result()
         runner.run(result)
         self.assertThat(messages, Equals([]))
+
+    def test_log_to_twisted(self):
+        # If suppress_twisted_logging is False, we log to the default Twisted
+        # loggers.
+        messages = []
+        publisher, _ = _get_global_publisher_and_observers()
+        publisher.addObserver(messages.append)
+
+        class LogSomething(TestCase):
+            def test_something(self):
+                log.msg("foo")
+
+        test = LogSomething('test_something')
+        runner = self.make_runner(test, suppress_twisted_logging=False)
+        result = self.make_result()
+        runner.run(result)
+        self.assertThat(
+            messages,
+            MatchesListwise([ContainsDict({'message': Equals(('foo',))})]))
 
     def test_debugging_unchanged_during_test_by_default(self):
         debugging = [(defer.Deferred.debug, DelayedCall.debug)]

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -937,15 +937,15 @@ class TestErrorObserver(NeedsTwistedTestCase):
 
 
 class TestCaptureTwistedLogs(NeedsTwistedTestCase):
-    """Tests for _CaptureTwistedLogs."""
+    """Tests for CaptureTwistedLogs."""
 
     def test_captures_logs(self):
-        # _CaptureTwistedLogs stores all Twisted log messages as a detail.
-        from testtools.deferredruntest import _CaptureTwistedLogs
+        # CaptureTwistedLogs stores all Twisted log messages as a detail.
+        from testtools.deferredruntest import CaptureTwistedLogs
 
         class SomeTest(TestCase):
             def test_something(self):
-                self.useFixture(_CaptureTwistedLogs())
+                self.useFixture(CaptureTwistedLogs())
                 log.msg('foo')
 
         test = SomeTest('test_something')


### PR DESCRIPTION
This is the fix to testtools necessary to remedy FLOC-3469, in which we aren't getting logs from acceptance tests to test.log.

The upstream bugs are:
- https://bugs.launchpad.net/testtools/+bug/942785
- https://bugs.launchpad.net/testtools/+bug/1515362

This builds on testing-cabal/testtools#171, and will also be submitted as a PR to core testtools.

However, since it's taking days to get patches landed in testtools and since these delays are having a direct & significant impact on our development velocity (flaky tests; debugging info from failing tests), I want to float the idea of maintaining a temporary fork.
